### PR TITLE
updated http to accept any content header that includes xml

### DIFF
--- a/config/http.js
+++ b/config/http.js
@@ -82,7 +82,8 @@ module.exports.http = {
       // Create and return the middleware function
       return function(req, res, next) {
         // If we see an application/xml header, parse the body as XML
-        if (req.headers['content-type'] == 'application/xml') {
+        var cType =req.headers['content-type'];
+        if (cType.indexOf('xml')>-1) {
           return xmlparser(req, res, next);
         }
         // Otherwise use Skipper to parse the body

--- a/config/http.js
+++ b/config/http.js
@@ -83,8 +83,10 @@ module.exports.http = {
       return function(req, res, next) {
         // If we see an application/xml header, parse the body as XML
         var cType =req.headers['content-type'];
-        if (cType.indexOf('xml')>-1) {
-          return xmlparser(req, res, next);
+        if (cType){
+          if (cType.indexOf('xml')>-1) {
+            return xmlparser(req, res, next);
+          }
         }
         // Otherwise use Skipper to parse the body
         return skipper(req, res, next);


### PR DESCRIPTION
Firstly thanks for the helpful repo, it works well. In the case I was working with I had to change the original: req.headers['content-type'] == 'application/xml' as what was sent from recurly (a billing service) was 'application/xml; charset=utf-8', to make this generic I'm recommending updating it to: var cType =req.headers['content-type']; if (cType.indexOf('xml')>-1) { which seems to work well from some quick testing. Cheers.
